### PR TITLE
Bug when number of phab users per instance is > 100

### DIFF
--- a/lib/phabricator/user.rb
+++ b/lib/phabricator/user.rb
@@ -8,7 +8,7 @@ module Phabricator
     attr_accessor :name
 
     def self.populate_all
-      response = client.request(:post, 'user.query')
+      response = client.request(:post, 'user.query', {limit: 1000})
 
       response['result'].each do |data|
         user = User.new(data)


### PR DESCRIPTION
By default, phabricator only sends 100 users in response to `user.query`. This is probably not the right solution to fix it, but I wanted to report the issue with a direct reference to the code involved.

There doesn't seem to be way to do "with no limit", so it's probably necessary to work with conduit's pagination (the offset parameter) to make this work when a phab instance has an arbitrary number of users.
