### PR TITLE
Better user and project lookups!

### DIFF
--- a/lib/phabricator/project.rb
+++ b/lib/phabricator/project.rb
@@ -17,11 +17,9 @@ module Phabricator
     end
 
     def self.find_by_name(name)
-      # Re-populate if we couldn't find it in the cache (this applies to
-      # if the cache is empty as well).
-      populate_all unless @@cached_projects[name]
+      populate_all if @@cached_projects.empty?
 
-      @@cached_projects[name]
+      @@cached_projects[name] || refresh_cache_for_project(name)
     end
 
     def initialize(attributes)
@@ -34,6 +32,16 @@ module Phabricator
 
     def self.client
       @client ||= Phabricator::ConduitClient.instance
+    end
+
+    def self.refresh_cache_for_project(name)
+      response = client.request(:post, 'project.query', { names: [ name ] })
+      response['result']['data'].each do |phid, data|
+        project = Project.new(data)
+        @@cached_projects[project.name] = project
+      end
+
+      @@cached_projects[name]
     end
   end
 end


### PR DESCRIPTION
This uses a fallback to query by name if the cache doesn't have the item. If
you have over the default page size (100) then populate_all does not in fact
populate all. This optimistically loads the first 100 but then after that looks
them up by name.

r? @amfeng || @astrieanna 