### PR TITLE
Allow passing in Phabricator:: objects for the fields to create a task.

### DIFF
--- a/lib/phabricator.rb
+++ b/lib/phabricator.rb
@@ -4,6 +4,16 @@ require 'phabricator/logging'
 
 module Phabricator
   extend Phabricator::Config
+
+  def self.lookup_project(item)
+    return item if item.kind_of?(::Phabricator::Project)
+    return ::Phabricator::Project.find_by_name(item)
+  end
+
+  def self.lookup_user(item)
+    return item if item.kind_of?(::Phabricator::User)
+    return ::Phabricator::User.find_by_name(item)
+  end
 end
 
 require 'phabricator/conduit_client'

--- a/lib/phabricator/maniphest/task.rb
+++ b/lib/phabricator/maniphest/task.rb
@@ -33,9 +33,9 @@ module Phabricator::Maniphest
         title: title,
         description: description,
         priority: Priority.send(priority),
-        projectPHIDs: projects.map {|p| Phabricator::Project.find_by_name(p).phid },
-        ownerPHID: owner ? Phabricator::User.find_by_name(owner).phid : nil,
-        ccPHIDs: ccs.map {|c| Phabricator::User.find_by_name(c).phid }
+        projectPHIDs: projects.compact.map { |p| ::Phabricator.lookup_project(p).phid },
+        ownerPHID: owner ? ::Phabricator.lookup_user(owner).phid : nil,
+        ccPHIDs: ccs.compact.map { |c| ::Phabricator.lookup_user(c).phid }
       }.merge(other))
 
       data = response['result']

--- a/lib/phabricator/maniphest/task.rb
+++ b/lib/phabricator/maniphest/task.rb
@@ -34,7 +34,7 @@ module Phabricator::Maniphest
         description: description,
         priority: Priority.send(priority),
         projectPHIDs: projects.compact.map { |p| ::Phabricator.lookup_project(p).phid },
-        ownerPHID: owner ? ::Phabricator.lookup_user(owner).phid : nil,
+        ownerPHID: owner.nil? ? nil : ::Phabricator.lookup_user(owner).phid,
         ccPHIDs: ccs.compact.map { |c| ::Phabricator.lookup_user(c).phid }
       }.merge(other))
 


### PR DESCRIPTION
Often times we're writing code that already has a fully initialized Project or User, so having to pass in the name adds some additional cruft to the code. This just proxies the lookup through a method that loads if it's not already the expected object.

r? @astrieanna || @amfeng 