### PR TITLE
Add property declarations to PhabObject

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    phabricator (0.0.5)
+    phabricator (0.0.8)
       rest-client
 
 GEM
@@ -9,9 +9,13 @@ GEM
   specs:
     ansi (1.4.3)
     builder (3.2.2)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
     hashie (2.0.5)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     metaclass (0.0.4)
-    mime-types (2.2)
+    mime-types (2.6.2)
     minitest (4.7.5)
     minitest-reporters (0.14.24)
       ansi
@@ -20,11 +24,18 @@ GEM
       powerbar
     mocha (1.0.0)
       metaclass (~> 0.0.1)
+    netrc (0.10.3)
     powerbar (1.0.11)
       ansi (~> 1.4.0)
       hashie (>= 1.1.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rake (10.4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   ruby
@@ -35,3 +46,7 @@ DEPENDENCIES
   minitest-reporters
   mocha
   phabricator!
+  rake
+
+BUNDLED WITH
+   1.10.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'rake/testtask'
+
+task :default => [:test]
+
+Rake::TestTask.new do |t|
+  t.pattern = './test/**/*_test.rb'
+end

--- a/lib/phabricator/phab_object.rb
+++ b/lib/phabricator/phab_object.rb
@@ -2,18 +2,126 @@ require 'phabricator/conduit_client'
 
 module Phabricator
   class PhabObject
-    attr_reader :phid
+    def self.inherited(other)
+      other.instance_eval do
+        @props = {}
+        @translatable_prop_names = []
+
+        prop :phid
+        attr_accessor :attrs
+      end
+    end
+
+    def self.prop(prop_sym, opts={})
+      @props[prop_sym] = opts
+      # For now, make props read-only, since we don't provide a method to save a changed object
+      define_method(prop_sym) {@attrs[prop_sym]}
+
+      name_prop = opts[:name_prop]
+      if name_prop
+        klass = opts[:class]
+        unless klass
+          raise ArgumentError.new("class is required when name_prop is provided")
+        end
+        @translatable_prop_names << prop_sym
+        define_method(name_prop) do
+          val = send(prop_sym)
+          if val.is_a?(Array)
+            val.map {|v| klass.name_from_raw_value(v)}
+          else
+            klass.name_from_raw_value(val)
+          end
+        end
+      end
+    end
+
+    def self.props
+      @props
+    end
+
+    def self.translatable_props
+      @translatable_prop_names.map {|prop_sym| [prop_sym, @props[prop_sym]]}
+    end
 
     def initialize(attributes)
-      @phid = attributes['phid']
+      @attrs = {}
+      keys = Set.new(attributes.keys.map(&:to_sym))
+      if keys.length != attributes.length
+        raise ArgumentError.new("attributes must not contain string and symbol keys of the same value")
+      end
+
+      self.class.props.each do |prop_sym, prop_opts|
+        next unless keys.include?(prop_sym)
+        keys.delete(prop_sym)
+        @attrs[prop_sym] = attributes[prop_sym] || attributes[prop_sym.to_s]
+      end
+
+      unless keys.empty?
+        raise ArgumentError.new("#{self.class}: Unrecognized properties: #{keys.to_a.join(", ")}")
+      end
     end
 
     def self.api_name
       self.name.split('::').last.downcase
     end
 
-    def self.query(fields={})
-      response = client.request(:post, "#{api_name}.query", fields)
+    def self.create_verb
+      'create'
+    end
+
+    def self.translate_name_props(attributes, is_query:)
+      attributes = attributes.dup
+      translatable_props.each do |prop, prop_opts|
+        name_prop = prop_opts.fetch(:name_prop)
+        if is_query
+          prop = prop_opts.fetch(:query_prop, prop)
+          name_prop = prop_opts.fetch(:query_name_prop, name_prop)
+        end
+        next unless attributes.key?(name_prop)
+
+        if attributes.key?(prop)
+          raise ArgumentError.new("Cannot include both #{prop} and #{name_prop}")
+        end
+
+        attr_val = attributes.delete(name_prop)
+        klass = prop_opts.fetch(:class)
+        if attr_val.is_a?(Array)
+          attributes[prop] = attr_val.map {|name| klass.raw_value_from_name(name)}
+        else
+          attributes[prop] = klass.raw_value_from_name(attr_val)
+        end
+      end
+      attributes
+    end
+
+    def self.create(attributes={})
+      attributes = translate_name_props(attributes, is_query: false)
+      response = client.request(:post, "#{api_name}.#{create_verb}", attributes)
+      data = response['result']
+
+      # TODO: Error handling
+
+      self.new(data)
+    end
+
+    def update(attributes)
+      attributes = self.class.translate_name_props(attributes, is_query: false)
+      if attributes.key?(:id)
+        raise ArgumentError.new("id is not allowed for update (it's automatically included)")
+      end
+      attributes[:id] = id
+
+      response = self.class.client.request(:post, "#{api_name}.update", attributes)
+      data = response['result']
+
+      # TODO: Error handling
+
+      self.class.new(data)
+    end
+
+    def self.query(attributes={})
+      attributes = translate_name_props(attributes, is_query: true)
+      response = client.request(:post, "#{api_name}.query", attributes)
       items = response['result']
 
       # Phab is horrible; some endpoints put use a 'data' subhash, some don't
@@ -27,6 +135,14 @@ module Phabricator
       end
 
       items.map {|item| self.new(item)}
+    end
+
+    def self.lookup_project_phid(project_name)
+      Phabricator.lookup_project(project_name).phid
+    end
+
+    def self.lookup_user_phid(user_name)
+      Phabricator.lookup_user(user_name).phid
     end
 
     private

--- a/lib/phabricator/project.rb
+++ b/lib/phabricator/project.rb
@@ -4,8 +4,8 @@ module Phabricator
   class Project < PhabObject
     @@cached_projects = {}
 
-    attr_reader :id
-    attr_accessor :name
+    prop :id
+    prop :name
 
     def self.populate_all
       query.each do |project|
@@ -19,10 +19,13 @@ module Phabricator
       @@cached_projects[name] || refresh_cache_for_project(name)
     end
 
-    def initialize(attributes)
-      super
-      @id = attributes['id']
-      @name = attributes['name']
+    def self.raw_value_from_name(name)
+      find_by_name(name).phid
+    end
+
+    def self.name_from_raw_value(raw_value)
+      # TODO: implement me
+      raise NotImplementedError
     end
 
     private

--- a/lib/phabricator/user.rb
+++ b/lib/phabricator/user.rb
@@ -4,7 +4,12 @@ module Phabricator
   class User < PhabObject
     @@cached_users = {}
 
-    attr_accessor :phid, :name, :attrs
+    prop :userName
+
+    # alias for backwards compatibility
+    def name
+      userName
+    end
 
     def self.populate_all
       query.each do |user|
@@ -18,10 +23,13 @@ module Phabricator
       @@cached_users[name] || refresh_cache_for_user(name)
     end
 
-    def initialize(attributes)
-      @phid = attributes['phid']
-      @name = attributes['userName']
-      @attrs = attributes
+    def self.raw_value_from_name(name)
+      find_by_name(name).phid
+    end
+
+    def self.name_from_raw_value(raw_value)
+      # TODO: implement me
+      raise NotImplementedError
     end
 
     private

--- a/lib/phabricator/version.rb
+++ b/lib/phabricator/version.rb
@@ -1,3 +1,3 @@
 module Phabricator
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end

--- a/phabricator.gemspec
+++ b/phabricator.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '< 5.0'
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'mocha'
-
+  spec.add_development_dependency('rake')
+  
   spec.add_development_dependency 'bundler', '~> 1.3'
 end

--- a/test/_lib.rb
+++ b/test/_lib.rb
@@ -4,6 +4,7 @@ require 'bundler/setup'
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'mocha/setup'
+require 'phabricator'
 
 module PhabricatorTests
   class Test < ::MiniTest::Spec

--- a/test/unit/_lib.rb
+++ b/test/unit/_lib.rb
@@ -2,6 +2,8 @@ require File.expand_path('../../_lib', __FILE__)
 
 module PhabricatorTests::Unit
   class Test < PhabricatorTests::Test
-    include Stubs
+    before do
+      Phabricator::ConduitClient.stubs(:new => mock)
+    end
   end
 end

--- a/test/unit/task_test.rb
+++ b/test/unit/task_test.rb
@@ -1,0 +1,69 @@
+require_relative '_lib'
+
+module PhabricatorTests::Unit
+  class TaskTest < Test
+    include Phabricator
+    include Phabricator::Maniphest
+
+    it 'accesses raw props and name_props' do
+      task = Task.new(
+        title: 'foo',
+        description: 'bar',
+        priority: 50,
+        projectPHIDs: ['phid1']
+      )
+      assert_equal('foo', task.title)
+      assert_equal('bar', task.description)
+      assert_equal(50, task.priority)
+      assert_equal(['phid1'], task.projectPHIDs)
+      assert_equal('normal', task.priorityName)
+    end
+
+    it 'creates with raw props and name_props' do
+      Project.expects(:raw_value_from_name).with('project1').returns('pphid')
+      User.expects(:raw_value_from_name).with('owner1').returns('ophid')
+
+      Project.client.expects(:request).with(
+        :post,
+        "maniphest.createtask",
+        {
+          priority: 80,
+          projectPHIDs: ['pphid'],
+          ownerPHID: 'ophid',
+          ccPHIDs: ['ccphid'],
+        }
+      ).returns('result' => {})
+
+      Task.create(
+        priorityName: 'high',
+        projectNames: ['project1'],
+        ownerName: 'owner1',
+        ccPHIDs: ['ccphid'],
+      )
+    end
+
+    it 'queries with raw props and name_props' do
+      Project.expects(:raw_value_from_name).with('project1').returns('pphid')
+      User.expects(:raw_value_from_name).with('owner1').returns('ophid')
+
+      Project.client.expects(:request).with(
+        :post,
+        "maniphest.query",
+        {
+          priority: 80,
+          projectPHIDs: ['pphid'],
+          ownerPHIDs: ['ophid'],
+          ccPHIDs: ['ccphid'],
+        }
+      ).returns('result' => {})
+
+      Task.query(
+        priorityName: 'high',
+        projectNames: ['project1'],
+        ownerNames: ['owner1'],
+        ccPHIDs: ['ccphid'],
+      )
+    end
+
+  end
+end


### PR DESCRIPTION
This lets us add consistent behavior among initialize, create, update, and property accessor methods.

As an initial set of property options, this PR adds the ability to automatically translate names to raw values (usually PHIDs, but can also be things like priority numbers). This generalizes and extends the behavior that was in the old Task.create method.

As a final bonus, this includes the first ever tests for this repo. :)

r? @jshirley 
cc @amfeng @astrieanna
